### PR TITLE
Fix URL encoding

### DIFF
--- a/mopidy_subsonic/client.py
+++ b/mopidy_subsonic/client.py
@@ -8,6 +8,7 @@ import libsonic
 import time
 import re
 import itertools
+import urllib
 
 from mopidy.models import Track, Album, Artist, Playlist
 
@@ -430,9 +431,9 @@ class SubsonicRemoteClient(object):
                           self.api._port,
                           self.api._serverPath,
                           'stream.view',
-                          id,
-                          self.api._username,
-                          self.api._rawPass)
+                          urllib.quote_plus(id),
+                          urllib.quote_plus(self.api._username),
+                          urllib.quote_plus(self.api._rawPass))
         return uri
 
     def search_artist(self, artist):


### PR DESCRIPTION
This fixes an issue where a username or password with special characters in it will cause the request to Subsonic to fail with `<error code="10" message="Required parameter is missing."/>`. 

(Working on the `browse-and-refactor` branch as it is the only version of the code that actually runs properly. Let me know if I should rebase.)
